### PR TITLE
Migrate diagnostic jump.float to on_jump

### DIFF
--- a/home/.config/nvim/lua/config/diagnostic.lua
+++ b/home/.config/nvim/lua/config/diagnostic.lua
@@ -19,6 +19,17 @@ vim.diagnostic.config({
     source = true,
   },
   jump = {
-    float = true,
+    --- @param diagnostic? vim.Diagnostic
+    --- @param bufnr integer
+    on_jump = function(diagnostic, bufnr)
+      if not diagnostic then
+        return
+      end
+      vim.diagnostic.open_float({
+        bufnr = bufnr,
+        scope = 'cursor',
+        focus = false,
+      })
+    end,
   },
 })


### PR DESCRIPTION
:warning: WARNING opts.jump.float is deprecated. Feature will be removed in Nvim 0.14

> ```lua
> if opts.float then
>   vim.deprecate('opts.float', 'opts.on_jump', '0.14')
>   local float_opts = opts.float
>   float_opts = type(float_opts) == 'table' and float_opts or {}
> 
>   opts.on_jump = function(_, bufnr)
>     M.open_float(vim.tbl_extend('keep', float_opts, {
>       bufnr = bufnr,
>       scope = 'cursor',
>       focus = false,
>     }))
>   end
> 
>   opts.float = nil ---@diagnostic disable-line
> end
> ```
>
> https://github.com/neovim/neovim/blob/bebf949f1fc6ff321cdfb8541ba5450cfc151ddf/runtime/lua/vim/diagnostic.lua#L1238-L1252